### PR TITLE
Added a linked Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@ Bitcoin is a groundbreaking technology that has large potential to fundamentally
  
 <a name="toc"></a>Below are some essential concepts and explanations that I’ve come to believe are the most important to convey in discussion.
 
-### [Bitcoin is a technology for everybody (neutrality)](#neutrality)
-### [Bitcoin preserves financial privacy (not anonymity)](#financial-privacy)
-### [Bitcoin is an alternative payment method](#payment-method)
-### [Bitcoin is a technical breakthrough and has massive future possibilities](#technical-breakthrough)
-### [Bitcoin has an ultra secure core protocol](#ultra-secure-core)
-### [Bitcoin’s volatility is good for consumers](#volatility)
-### [Bitcoin is available to everyone](#available-to-everyone)
-### [Bitcoin is still in BETA - act appropriately](#beta)
-### [Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run](#fixed-monetary-policy)
-### [Bitcoin is self-regulating](#self-regulating)
-### [Bitcoin is already heavily regulated by the US government and the media](#already-heavily-regulated)
-### [Bitcoin has multiple uses](#multiple-uses)
-### [Bitcoin operates over a truly open payment network](#open)
+* **[Bitcoin is a technology for everybody (neutrality)](#neutrality)**
+* **[Bitcoin preserves financial privacy (not anonymity)](#financial-privacy)**
+* **[Bitcoin is an alternative payment method](#payment-method)**
+* **[Bitcoin is a technical breakthrough and has massive future possibilities](#technical-breakthrough)**
+* **[Bitcoin has an ultra secure core protocol](#ultra-secure-core)**
+* **[Bitcoin’s volatility is good for consumers](#volatility)**
+* **[Bitcoin is available to everyone](#available-to-everyone)**
+* **[Bitcoin is still in BETA - act appropriately](#beta)**
+* **[Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run](#fixed-monetary-policy)**
+* **[Bitcoin is self-regulating](#self-regulating)**
+* **[Bitcoin is already heavily regulated by the US government and the media](#already-heavily-regulated)**
+* **[Bitcoin has multiple uses](#multiple-uses)**
+* **[Bitcoin operates over a truly open payment network](#open)**
 
+---
 
 ## Bitcoin is a technology for everybody (neutrality) <a name="neutrality"></a>
 It is essential that Bitcoin remains a neutral technology unrelated to any group, culture, government, religion, language, country, or movement. Bitcoin is not just for computer scientists or libertarians. Bitcoin is a technology that any person or group can use to achieve their own objectives.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 Bitcoin is a groundbreaking technology that has large potential to fundamentally change the way people store and transmit value. However, the technology in and of itself will not guarantee mainstream adoption. With increasing regulatory scrutiny and media attention, it is critical that Bitcoin is framed properly to allow both consumers and regulators to accurately understand its risks and benefits. As the Bitcoin ecosystem continues to grow and expand, it is important that the community has a common foundation in language and theory. The Bitcoin community is Bitcoin's #1 voice, and consistency in messaging will be a force multiplier.
  
-Below are some essential concepts and explanations that I’ve come to believe are the most important to convey in discussion.
+<a name="toc"></a>Below are some essential concepts and explanations that I’ve come to believe are the most important to convey in discussion.
 
-## Bitcoin is a technology for everybody (neutrality)
+### [Bitcoin is a technology for everybody (neutrality)](#neutrality)
+### [Bitcoin preserves financial privacy (not anonymity)](#financial-privacy)
+### [Bitcoin is an alternative payment method](#payment-method)
+### [Bitcoin is a technical breakthrough and has massive future possibilities](#technical-breakthrough)
+### [Bitcoin has an ultra secure core protocol](#ultra-secure-core)
+### [Bitcoin’s volatility is good for consumers](#volatility)
+### [Bitcoin is available to everyone](#available-to-everyone)
+### [Bitcoin is still in BETA - act appropriately](#beta)
+### [Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run](#fixed-monetary-policy)
+### [Bitcoin is self-regulating](#self-regulating)
+### [Bitcoin is already heavily regulated by the US government and the media](#already-heavily-regulated)
+### [Bitcoin has multiple uses](#multiple-uses)
+### [Bitcoin operates over a truly open payment network](#open)
+
+
+## Bitcoin is a technology for everybody (neutrality) <a name="neutrality"></a>
 It is essential that Bitcoin remains a neutral technology unrelated to any group, culture, government, religion, language, country, or movement. Bitcoin is not just for computer scientists or libertarians. Bitcoin is a technology that any person or group can use to achieve their own objectives.
 
 Mass adoption will only occur when people can adopt Bitcoin without the fear that they are associating their identity with something else. Everyone must make a valiant effort to disassociate Bitcoin from political or cultural leanings.
 
 Further reading: [1](https://www.youtube.com/watch?v=BT8FXQN-9-A), [2](http://www.paulgraham.com/identity.html)
 
-## Bitcoin preserves financial privacy (not anonymity)
+## Bitcoin preserves financial privacy (not anonymity) <a name="financial-privacy"></a>
 The fact that Bitcoin transactions are anonymous is inaccurate. Bitcoin transactions are all publicly visible via a globally distributed ledger through [pseudonymous](http://en.wikipedia.org/wiki/Pseudonymity) identities, and these transactions are all chained together. Since many transactions pass through known entities (ex. hosted wallets, exchanges, or merchants), transactions can be traced from known points on the chain quite easily.
 
 There is also an overwhelmingly positive attribute about Bitcoin: financial privacy. Bitcoin, as opposed to credit/debit cards, checks, ACH, wire, and many other payment methods, allow people to preserve their financial privacy when making a transaction.
@@ -18,7 +33,7 @@ Millions of personal identities are stolen every year because large companies ha
 
 Further reading: [1](http://www.law.cornell.edu/uscode/text/12/chapter-35), [2](http://en.wikipedia.org/wiki/Right_to_Financial_Privacy_Act), [3](https://www.fdic.gov/consumers/privacy/yourrights/), [4](http://plato.stanford.edu/entries/privacy/), [5](http://www.ftc.gov/sites/default/files/documents/reports/consumer-sentinel-network-data-book-january/sentinel-cy2012.pdf), [6](http://en.wikipedia.org/wiki/Credit_card_fraud), [7](http://krebsonsecurity.com/category/data-breaches/), [8](http://www.cnet.com/pictures/the-credit-card-data-breaches-retailers/), [9](http://www.heritage.org/research/reports/2014/10/cyber-attacks-on-us-companies-in-2014), [10](http://fc13.ifca.ai/proc/1-3.pdf), [11](http://www.coindesk.com/how-anonymous-is-bitcoin/)
 
-## Bitcoin is an alternative payment method
+## Bitcoin is an alternative payment method <a name="payment-method"></a>
 In the US alone, there are over a dozen payment methods that are supported by various banks, acquirers, issuers, and processors. Some examples include:
 
 * Cash
@@ -36,7 +51,7 @@ All have their pros and cons and are used because transactions come in many shap
 
 Further reading: [1](http://www.amazon.com/Payments-Systems-U-S-Carol-Benson/dp/098278970X), [2](http://en.wikipedia.org/wiki/Alternative_payments), [3](https://bitcoin.org/en/bitcoin-for-businesses), [4](https://coinreport.net/coin-101/advantages-and-disadvantages-of-bitcoin/), [5](http://www.forbes.com/sites/groupthink/2014/02/13/why-we-accept-bitcoin/)
 
-## Bitcoin is a technical breakthrough and has massive future possibilities
+## Bitcoin is a technical breakthrough and has massive future possibilities <a name="technical-breakthrough"></a>
 It is important to make people aware of the highly-technical foundation of Bitcoin and it being a technical breakthrough. For a highly technical audience, it may be best to focus on Bitcoin’s technical topics.
 
 Bitcoin is an elegant solution to a difficult computer science problem (the [Byzantine Generals Problem](http://en.wikipedia.org/wiki/Byzantine_fault_tolerance)) that has been contemplated for decades. This is the first time where value can be transferred electronically in a peer-to-peer fashion without an intermediary. The internet made it possible to share information, and Bitcoin makes it possible to transfer ownership of value/information. Bitcoin makes it possible to decentralize services we couldn't previously decentralize and establish consensus in highly distributed large-scale systems.
@@ -54,7 +69,7 @@ Related topics that can be used in discussion:
 
 Further reading: [1](https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/), [2](http://paulbohm.com/articles/bitcoins-value-is-decentralization/), [3](http://nonchalantrepreneur.com/post/70130104170/bitcoin-and-the-byzantine-generals-problem), [4](https://en.bitcoin.it/wiki/Block_chain), [5](http://www.newscientist.com/article/mg22129553.700-bitcoin-how-its-core-technology-will-change-the-world.html#.VI1NHaTF9Co)
 
-## Bitcoin has an ultra secure core protocol
+## Bitcoin has an ultra secure core protocol <a name="ultra-secure-core"></a>
 The Bitcoin protocol has been vetted and tested by top computer science, cryptography, and security experts around the world.
 
 Bitcoin relies on a combination of algorithms / hash functions which are heavily-used and relied upon around the world including ECDSA, SHA-2, SHA-256. Bitcoin is also a dynamic system that can be changed and adapted to address specific security vulnerabilities. 
@@ -63,7 +78,7 @@ It is important to make a distinction between the Bitcoin protocol and either Bi
 
 Further reading: [1](https://bitcoin.org/en/faq#is-bitcoin-secure), [2](http://www.michaelnielsen.org/ddi/how-the-bitcoin-protocol-actually-works/), [3](http://crypto.stackexchange.com/questions/316/how-secure-is-the-bitcoin-protocol), [4](https://en.bitcoin.it/wiki/Protocol_rules)
 
-## Bitcoin’s volatility is good for consumers
+## Bitcoin’s volatility is good for consumers <a name="volatility"></a>
 
 Volatility is a signal to consumers that makes them fully aware of the risks associated with Bitcoin. As Bitcoin is still in BETA, someone purchasing Bitcoin is aware of the volatility which re-emphasizes the risk of investing in Bitcoin.
 
@@ -73,18 +88,18 @@ Volatility will likely decrease over time. As Bitcoin’s market capitalization 
 
 Further reading: [1](http://www.xe.com/currencytables/?from=USD&date=2014-12-05), [2](http://www.washingtonpost.com/blogs/the-switch/wp/2013/12/09/heres-why-volatility-isnt-a-big-problem-for-bitcoin/), [3](http://www.forbes.com/sites/timothylee/2013/04/12/bitcoins-volatility-is-a-disadvantage-but-not-a-fatal-one/), [4](http://www.coindesk.com/bitcoins-volatility-problem-may-soon-solved/), [5](http://www.coindesk.com/bitcoin-vs-argentine-peso-worse/)
 
-## Bitcoin is available to everyone
+## Bitcoin is available to everyone <a name="available-to-everyone"></a>
 Unlike applying for a credit card or bank account which has many personal and financial requirements, Bitcoin is available to everyone. It also has many options. If you’d like to use a hosted wallet or exchange service, you’ll have to go through some degree of identity verification and comply with the provider’s requirements. However, this is just an option. Otherwise, you can download your own local wallet and gain complete control of your Bitcoin with a simple computer program.
 
 Also, if you want to be involved in the security and evolution of the network, anybody in the world can participate in multiple ways. If you’d like to contribute to the Bitcoin Core technology, you can [contribute via Github](https://github.com/bitcoin/bitcoin). However, a majority of the network would have to agree with your changes. To be a part of the decision-making community, you can participate in the [mining process](http://bitcoinminer.net/category/basic-overview-of-bitcoin-mining/).
 
-## Bitcoin is still in BETA - act appropriately
+## Bitcoin is still in BETA - act appropriately <a name="beta"></a>
 While the protocol is ultra-secure and heavily tested, Bitcoin is still in its infancy. This applies to both the core protocol, surrounding companies/services, and Bitcoin as a currency / transaction medium. People should clearly understand this risk and only participate with what they can afford to lose. Telling people that they should put a lot of money or resources into Bitcoin as a great way to make money is the wrong message to send.
 
-## Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run
+## Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run <a name="fixed-monetary-policy"></a>
 Bitcoin volatility is present but largely market-driven. Volatility in fiat currencies is not only caused by market forces, but also monetary policy decisions that have little transparency or predictability. A fixed monetary supply (21 million Bitcoin) may provide greater certainty and predictability that allows users to make more educated decisions. 
 
-## Bitcoin is self-regulating
+## Bitcoin is self-regulating <a name="self-regulating"></a>
 Bitcoin is self-regulating and makes sure certain people don’t abuse the protocol. Everyone is incentivized to make sure Bitcoin is successful, from users to miners. And, when bad-actors try to take advantage of the protocol, everyone responds to take appropriate actions.
 
 This is one of the reasons why Bitcoin is unique compared to other payments networks. Other payments networks require heavy regulation over a large, central authority.  Because Bitcoin is self-regulating and requires majority consensus on rules/protocol, it does not require nearly as heavy regulation.
@@ -95,15 +110,15 @@ Finally, there are multiple groups and associations that establish standards of 
 
 Further reading: [1](https://www.youtube.com/watch?v=xUNGFZDO8mM), [2](http://www.coindesk.com/bitcoin-industry-leaders-launch-data-a-self-regulatory-body/), [3](https://en.bitcoin.it/wiki/Mining), [4](http://www.righto.com/2014/02/bitcoin-mining-hard-way-algorithms.html), [5](http://www.coindesk.com/ghash-commits-40-hashrate-cap-bitcoin-mining-summit/)
 
-## Bitcoin is already heavily regulated by the US government and the media
+## Bitcoin is already heavily regulated by the US government and the media <a name="already-heavily-regulated"></a>
 Bitcoin companies in the US have already faced massive regulatory pressure. FinCEN has issued [guidance](http://fincen.gov/statutes_regs/guidance/html/FIN-2013-G001.html) on virtual currency companies [twice](http://www.fincen.gov/news_room/rp/rulings/pdf/FIN-2014-R011.pdf). The Senate has held [hearings](http://www.hsgac.senate.gov/hearings/beyond-silk-road-potential-risks-threats-and-promises-of-virtual-currencies) on Bitcoin. The IRS has issued [tax guidance](http://www.irs.gov/pub/irs-drop/n-14-21.pdf) on Bitcoin. The CFPB has issued an [advisory notice](http://files.consumerfinance.gov/f/201408_cfpb_consumer-advisory_virtual-currencies.pdf) to consumers on how to deal with Bitcoin. New York state has proposed a [BitLicense](http://www.dfs.ny.gov/about/press2014/pr1407171-vc.pdf) for virtual currency companies. Bitcoin companies operating in the US have substantial existing regulations and compliance requirements. This is exacerbated by the fact that Bitcoin companies are under heavy scrutiny and in the spotlight. Lots of regulators, reporters, banks, and traditional financial service companies are waiting for Bitcoin companies to make major mistakes.
 
-## Bitcoin has multiple uses
+## Bitcoin has multiple uses <a name="multiple-uses"></a>
 Bitcoin is not just a virtual currency. It is also a store of value, transaction medium, value transfer protocol, and distributed consensus system. Make people aware that all of the above exist and should be treated as relatively independent concepts. 
 
 The beauty of Bitcoin is the intersection of an arguably superior currency, store of value, transaction medium, value transfer protocol, and distributed consensus system all in one manifestation. However, Bitcoin does not have to succeed in all of these pillars for it to be successful. If someone is convinced that Bitcoin will never replace gold as a store of value, remind them to consider the other pillars of Bitcoin when analyzing Bitcoin as a whole.
 
-## Bitcoin operates over a truly open payment network
+## Bitcoin operates over a truly open payment network <a name="open"></a>
 Visa, Mastercard, ACH, wire transfers, and check images operate over a open-loop network which is a system of intermediaries (ex. financial institutions or banks) and end-points (ex. consumers or merchants). All of these payments methods did incredible things for digitizing payments and creating large-scale interoperability. 
 
 However, these older payment methods can be made significantly more efficient, frictionless, and open. In addition, these networks are owned by fee-taking central parties with ultimate decision-making abilities.
@@ -120,3 +135,4 @@ Here are some great resources to further strengthen your understanding of Bitcoi
 
 * [http://antonopoulos.com/](http://antonopoulos.com/) 
 * Myths/FAQ: [1](https://en.bitcoin.it/wiki/Myths), [2](https://bitcoin.org/en/faq), [3](https://en.bitcoin.it/wiki/Introduction)
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Millions of personal identities are stolen every year because large companies ha
 
 Further reading: [1](http://www.law.cornell.edu/uscode/text/12/chapter-35), [2](http://en.wikipedia.org/wiki/Right_to_Financial_Privacy_Act), [3](https://www.fdic.gov/consumers/privacy/yourrights/), [4](http://plato.stanford.edu/entries/privacy/), [5](http://www.ftc.gov/sites/default/files/documents/reports/consumer-sentinel-network-data-book-january/sentinel-cy2012.pdf), [6](http://en.wikipedia.org/wiki/Credit_card_fraud), [7](http://krebsonsecurity.com/category/data-breaches/), [8](http://www.cnet.com/pictures/the-credit-card-data-breaches-retailers/), [9](http://www.heritage.org/research/reports/2014/10/cyber-attacks-on-us-companies-in-2014), [10](http://fc13.ifca.ai/proc/1-3.pdf), [11](http://www.coindesk.com/how-anonymous-is-bitcoin/)
 
-
 ## Bitcoin is an alternative payment method
 In the US alone, there are over a dozen payment methods that are supported by various banks, acquirers, issuers, and processors. Some examples include:
 
@@ -64,7 +63,7 @@ It is important to make a distinction between the Bitcoin protocol and either Bi
 
 Further reading: [1](https://bitcoin.org/en/faq#is-bitcoin-secure), [2](http://www.michaelnielsen.org/ddi/how-the-bitcoin-protocol-actually-works/), [3](http://crypto.stackexchange.com/questions/316/how-secure-is-the-bitcoin-protocol), [4](https://en.bitcoin.it/wiki/Protocol_rules)
 
-Bitcoin’s volatility is good for consumers
+## Bitcoin’s volatility is good for consumers
 
 Volatility is a signal to consumers that makes them fully aware of the risks associated with Bitcoin. As Bitcoin is still in BETA, someone purchasing Bitcoin is aware of the volatility which re-emphasizes the risk of investing in Bitcoin.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bitcoin is a groundbreaking technology that has large potential to fundamentally
 ---
 
 <a name="neutrality"></a>
-## Bitcoin is a technology for everybody (neutrality)
+## [Bitcoin is a technology for everybody (neutrality)](#toc)
 It is essential that Bitcoin remains a neutral technology unrelated to any group, culture, government, religion, language, country, or movement. Bitcoin is not just for computer scientists or libertarians. Bitcoin is a technology that any person or group can use to achieve their own objectives.
 
 Mass adoption will only occur when people can adopt Bitcoin without the fear that they are associating their identity with something else. Everyone must make a valiant effort to disassociate Bitcoin from political or cultural leanings.
@@ -27,7 +27,7 @@ Mass adoption will only occur when people can adopt Bitcoin without the fear tha
 Further reading: [1](https://www.youtube.com/watch?v=BT8FXQN-9-A), [2](http://www.paulgraham.com/identity.html)
 
 <a name="financial-privacy"></a>
-## Bitcoin preserves financial privacy (not anonymity)
+## [Bitcoin preserves financial privacy (not anonymity)](#toc)
 The fact that Bitcoin transactions are anonymous is inaccurate. Bitcoin transactions are all publicly visible via a globally distributed ledger through [pseudonymous](http://en.wikipedia.org/wiki/Pseudonymity) identities, and these transactions are all chained together. Since many transactions pass through known entities (ex. hosted wallets, exchanges, or merchants), transactions can be traced from known points on the chain quite easily.
 
 There is also an overwhelmingly positive attribute about Bitcoin: financial privacy. Bitcoin, as opposed to credit/debit cards, checks, ACH, wire, and many other payment methods, allow people to preserve their financial privacy when making a transaction.
@@ -37,7 +37,7 @@ Millions of personal identities are stolen every year because large companies ha
 Further reading: [1](http://www.law.cornell.edu/uscode/text/12/chapter-35), [2](http://en.wikipedia.org/wiki/Right_to_Financial_Privacy_Act), [3](https://www.fdic.gov/consumers/privacy/yourrights/), [4](http://plato.stanford.edu/entries/privacy/), [5](http://www.ftc.gov/sites/default/files/documents/reports/consumer-sentinel-network-data-book-january/sentinel-cy2012.pdf), [6](http://en.wikipedia.org/wiki/Credit_card_fraud), [7](http://krebsonsecurity.com/category/data-breaches/), [8](http://www.cnet.com/pictures/the-credit-card-data-breaches-retailers/), [9](http://www.heritage.org/research/reports/2014/10/cyber-attacks-on-us-companies-in-2014), [10](http://fc13.ifca.ai/proc/1-3.pdf), [11](http://www.coindesk.com/how-anonymous-is-bitcoin/)
 
 <a name="payment-method"></a>
-## Bitcoin is an alternative payment method
+## [Bitcoin is an alternative payment method](#toc)
 In the US alone, there are over a dozen payment methods that are supported by various banks, acquirers, issuers, and processors. Some examples include:
 
 * Cash
@@ -56,7 +56,7 @@ All have their pros and cons and are used because transactions come in many shap
 Further reading: [1](http://www.amazon.com/Payments-Systems-U-S-Carol-Benson/dp/098278970X), [2](http://en.wikipedia.org/wiki/Alternative_payments), [3](https://bitcoin.org/en/bitcoin-for-businesses), [4](https://coinreport.net/coin-101/advantages-and-disadvantages-of-bitcoin/), [5](http://www.forbes.com/sites/groupthink/2014/02/13/why-we-accept-bitcoin/)
 
 <a name="technical-breakthrough"></a>
-## Bitcoin is a technical breakthrough and has massive future possibilities
+## [Bitcoin is a technical breakthrough and has massive future possibilities](#toc)
 It is important to make people aware of the highly-technical foundation of Bitcoin and it being a technical breakthrough. For a highly technical audience, it may be best to focus on Bitcoin’s technical topics.
 
 Bitcoin is an elegant solution to a difficult computer science problem (the [Byzantine Generals Problem](http://en.wikipedia.org/wiki/Byzantine_fault_tolerance)) that has been contemplated for decades. This is the first time where value can be transferred electronically in a peer-to-peer fashion without an intermediary. The internet made it possible to share information, and Bitcoin makes it possible to transfer ownership of value/information. Bitcoin makes it possible to decentralize services we couldn't previously decentralize and establish consensus in highly distributed large-scale systems.
@@ -75,7 +75,7 @@ Related topics that can be used in discussion:
 Further reading: [1](https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/), [2](http://paulbohm.com/articles/bitcoins-value-is-decentralization/), [3](http://nonchalantrepreneur.com/post/70130104170/bitcoin-and-the-byzantine-generals-problem), [4](https://en.bitcoin.it/wiki/Block_chain), [5](http://www.newscientist.com/article/mg22129553.700-bitcoin-how-its-core-technology-will-change-the-world.html#.VI1NHaTF9Co)
 
 <a name="ultra-secure-core"></a>
-## Bitcoin has an ultra secure core protocol
+## [Bitcoin has an ultra secure core protocol](#toc)
 The Bitcoin protocol has been vetted and tested by top computer science, cryptography, and security experts around the world.
 
 Bitcoin relies on a combination of algorithms / hash functions which are heavily-used and relied upon around the world including ECDSA, SHA-2, SHA-256. Bitcoin is also a dynamic system that can be changed and adapted to address specific security vulnerabilities. 
@@ -85,7 +85,7 @@ It is important to make a distinction between the Bitcoin protocol and either Bi
 Further reading: [1](https://bitcoin.org/en/faq#is-bitcoin-secure), [2](http://www.michaelnielsen.org/ddi/how-the-bitcoin-protocol-actually-works/), [3](http://crypto.stackexchange.com/questions/316/how-secure-is-the-bitcoin-protocol), [4](https://en.bitcoin.it/wiki/Protocol_rules)
 
 <a name="volatility"></a>
-## Bitcoin’s volatility is good for consumers
+## [Bitcoin’s volatility is good for consumers](#toc)
 
 Volatility is a signal to consumers that makes them fully aware of the risks associated with Bitcoin. As Bitcoin is still in BETA, someone purchasing Bitcoin is aware of the volatility which re-emphasizes the risk of investing in Bitcoin.
 
@@ -96,21 +96,21 @@ Volatility will likely decrease over time. As Bitcoin’s market capitalization 
 Further reading: [1](http://www.xe.com/currencytables/?from=USD&date=2014-12-05), [2](http://www.washingtonpost.com/blogs/the-switch/wp/2013/12/09/heres-why-volatility-isnt-a-big-problem-for-bitcoin/), [3](http://www.forbes.com/sites/timothylee/2013/04/12/bitcoins-volatility-is-a-disadvantage-but-not-a-fatal-one/), [4](http://www.coindesk.com/bitcoins-volatility-problem-may-soon-solved/), [5](http://www.coindesk.com/bitcoin-vs-argentine-peso-worse/)
 
 <a name="available-to-everyone"></a>
-## Bitcoin is available to everyone
+## [Bitcoin is available to everyone](#toc)
 Unlike applying for a credit card or bank account which has many personal and financial requirements, Bitcoin is available to everyone. It also has many options. If you’d like to use a hosted wallet or exchange service, you’ll have to go through some degree of identity verification and comply with the provider’s requirements. However, this is just an option. Otherwise, you can download your own local wallet and gain complete control of your Bitcoin with a simple computer program.
 
 Also, if you want to be involved in the security and evolution of the network, anybody in the world can participate in multiple ways. If you’d like to contribute to the Bitcoin Core technology, you can [contribute via Github](https://github.com/bitcoin/bitcoin). However, a majority of the network would have to agree with your changes. To be a part of the decision-making community, you can participate in the [mining process](http://bitcoinminer.net/category/basic-overview-of-bitcoin-mining/).
 
 <a name="beta"></a>
-## Bitcoin is still in BETA - act appropriately
+## [Bitcoin is still in BETA - act appropriately](#toc)
 While the protocol is ultra-secure and heavily tested, Bitcoin is still in its infancy. This applies to both the core protocol, surrounding companies/services, and Bitcoin as a currency / transaction medium. People should clearly understand this risk and only participate with what they can afford to lose. Telling people that they should put a lot of money or resources into Bitcoin as a great way to make money is the wrong message to send.
 
 <a name="fixed-monetary-policy"></a>
-## Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run
+## [Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run](#toc)
 Bitcoin volatility is present but largely market-driven. Volatility in fiat currencies is not only caused by market forces, but also monetary policy decisions that have little transparency or predictability. A fixed monetary supply (21 million Bitcoin) may provide greater certainty and predictability that allows users to make more educated decisions. 
 
 <a name="self-regulating"></a>
-## Bitcoin is self-regulating
+## [Bitcoin is self-regulating](#toc)
 Bitcoin is self-regulating and makes sure certain people don’t abuse the protocol. Everyone is incentivized to make sure Bitcoin is successful, from users to miners. And, when bad-actors try to take advantage of the protocol, everyone responds to take appropriate actions.
 
 This is one of the reasons why Bitcoin is unique compared to other payments networks. Other payments networks require heavy regulation over a large, central authority.  Because Bitcoin is self-regulating and requires majority consensus on rules/protocol, it does not require nearly as heavy regulation.
@@ -122,17 +122,17 @@ Finally, there are multiple groups and associations that establish standards of 
 Further reading: [1](https://www.youtube.com/watch?v=xUNGFZDO8mM), [2](http://www.coindesk.com/bitcoin-industry-leaders-launch-data-a-self-regulatory-body/), [3](https://en.bitcoin.it/wiki/Mining), [4](http://www.righto.com/2014/02/bitcoin-mining-hard-way-algorithms.html), [5](http://www.coindesk.com/ghash-commits-40-hashrate-cap-bitcoin-mining-summit/)
 
 <a name="already-heavily-regulated"></a>
-## Bitcoin is already heavily regulated by the US government and the media
+## [Bitcoin is already heavily regulated by the US government and the media](#toc)
 Bitcoin companies in the US have already faced massive regulatory pressure. FinCEN has issued [guidance](http://fincen.gov/statutes_regs/guidance/html/FIN-2013-G001.html) on virtual currency companies [twice](http://www.fincen.gov/news_room/rp/rulings/pdf/FIN-2014-R011.pdf). The Senate has held [hearings](http://www.hsgac.senate.gov/hearings/beyond-silk-road-potential-risks-threats-and-promises-of-virtual-currencies) on Bitcoin. The IRS has issued [tax guidance](http://www.irs.gov/pub/irs-drop/n-14-21.pdf) on Bitcoin. The CFPB has issued an [advisory notice](http://files.consumerfinance.gov/f/201408_cfpb_consumer-advisory_virtual-currencies.pdf) to consumers on how to deal with Bitcoin. New York state has proposed a [BitLicense](http://www.dfs.ny.gov/about/press2014/pr1407171-vc.pdf) for virtual currency companies. Bitcoin companies operating in the US have substantial existing regulations and compliance requirements. This is exacerbated by the fact that Bitcoin companies are under heavy scrutiny and in the spotlight. Lots of regulators, reporters, banks, and traditional financial service companies are waiting for Bitcoin companies to make major mistakes.
 
 <a name="multiple-uses"></a>
-## Bitcoin has multiple uses
+## [Bitcoin has multiple uses](#toc)
 Bitcoin is not just a virtual currency. It is also a store of value, transaction medium, value transfer protocol, and distributed consensus system. Make people aware that all of the above exist and should be treated as relatively independent concepts. 
 
 The beauty of Bitcoin is the intersection of an arguably superior currency, store of value, transaction medium, value transfer protocol, and distributed consensus system all in one manifestation. However, Bitcoin does not have to succeed in all of these pillars for it to be successful. If someone is convinced that Bitcoin will never replace gold as a store of value, remind them to consider the other pillars of Bitcoin when analyzing Bitcoin as a whole.
 
 <a name="open"></a>
-## Bitcoin operates over a truly open payment network
+## [Bitcoin operates over a truly open payment network](#toc)
 Visa, Mastercard, ACH, wire transfers, and check images operate over a open-loop network which is a system of intermediaries (ex. financial institutions or banks) and end-points (ex. consumers or merchants). All of these payments methods did incredible things for digitizing payments and creating large-scale interoperability. 
 
 However, these older payment methods can be made significantly more efficient, frictionless, and open. In addition, these networks are owned by fee-taking central parties with ultimate decision-making abilities.

--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ Bitcoin is a groundbreaking technology that has large potential to fundamentally
 
 ---
 
-## Bitcoin is a technology for everybody (neutrality) <a name="neutrality"></a>
+<a name="neutrality"></a>
+## Bitcoin is a technology for everybody (neutrality)
 It is essential that Bitcoin remains a neutral technology unrelated to any group, culture, government, religion, language, country, or movement. Bitcoin is not just for computer scientists or libertarians. Bitcoin is a technology that any person or group can use to achieve their own objectives.
 
 Mass adoption will only occur when people can adopt Bitcoin without the fear that they are associating their identity with something else. Everyone must make a valiant effort to disassociate Bitcoin from political or cultural leanings.
 
 Further reading: [1](https://www.youtube.com/watch?v=BT8FXQN-9-A), [2](http://www.paulgraham.com/identity.html)
 
-## Bitcoin preserves financial privacy (not anonymity) <a name="financial-privacy"></a>
+<a name="financial-privacy"></a>
+## Bitcoin preserves financial privacy (not anonymity)
 The fact that Bitcoin transactions are anonymous is inaccurate. Bitcoin transactions are all publicly visible via a globally distributed ledger through [pseudonymous](http://en.wikipedia.org/wiki/Pseudonymity) identities, and these transactions are all chained together. Since many transactions pass through known entities (ex. hosted wallets, exchanges, or merchants), transactions can be traced from known points on the chain quite easily.
 
 There is also an overwhelmingly positive attribute about Bitcoin: financial privacy. Bitcoin, as opposed to credit/debit cards, checks, ACH, wire, and many other payment methods, allow people to preserve their financial privacy when making a transaction.
@@ -34,7 +36,8 @@ Millions of personal identities are stolen every year because large companies ha
 
 Further reading: [1](http://www.law.cornell.edu/uscode/text/12/chapter-35), [2](http://en.wikipedia.org/wiki/Right_to_Financial_Privacy_Act), [3](https://www.fdic.gov/consumers/privacy/yourrights/), [4](http://plato.stanford.edu/entries/privacy/), [5](http://www.ftc.gov/sites/default/files/documents/reports/consumer-sentinel-network-data-book-january/sentinel-cy2012.pdf), [6](http://en.wikipedia.org/wiki/Credit_card_fraud), [7](http://krebsonsecurity.com/category/data-breaches/), [8](http://www.cnet.com/pictures/the-credit-card-data-breaches-retailers/), [9](http://www.heritage.org/research/reports/2014/10/cyber-attacks-on-us-companies-in-2014), [10](http://fc13.ifca.ai/proc/1-3.pdf), [11](http://www.coindesk.com/how-anonymous-is-bitcoin/)
 
-## Bitcoin is an alternative payment method <a name="payment-method"></a>
+<a name="payment-method"></a>
+## Bitcoin is an alternative payment method
 In the US alone, there are over a dozen payment methods that are supported by various banks, acquirers, issuers, and processors. Some examples include:
 
 * Cash
@@ -52,7 +55,8 @@ All have their pros and cons and are used because transactions come in many shap
 
 Further reading: [1](http://www.amazon.com/Payments-Systems-U-S-Carol-Benson/dp/098278970X), [2](http://en.wikipedia.org/wiki/Alternative_payments), [3](https://bitcoin.org/en/bitcoin-for-businesses), [4](https://coinreport.net/coin-101/advantages-and-disadvantages-of-bitcoin/), [5](http://www.forbes.com/sites/groupthink/2014/02/13/why-we-accept-bitcoin/)
 
-## Bitcoin is a technical breakthrough and has massive future possibilities <a name="technical-breakthrough"></a>
+<a name="technical-breakthrough"></a>
+## Bitcoin is a technical breakthrough and has massive future possibilities
 It is important to make people aware of the highly-technical foundation of Bitcoin and it being a technical breakthrough. For a highly technical audience, it may be best to focus on Bitcoin’s technical topics.
 
 Bitcoin is an elegant solution to a difficult computer science problem (the [Byzantine Generals Problem](http://en.wikipedia.org/wiki/Byzantine_fault_tolerance)) that has been contemplated for decades. This is the first time where value can be transferred electronically in a peer-to-peer fashion without an intermediary. The internet made it possible to share information, and Bitcoin makes it possible to transfer ownership of value/information. Bitcoin makes it possible to decentralize services we couldn't previously decentralize and establish consensus in highly distributed large-scale systems.
@@ -70,7 +74,8 @@ Related topics that can be used in discussion:
 
 Further reading: [1](https://www.khanacademy.org/economics-finance-domain/core-finance/money-and-banking/bitcoin/), [2](http://paulbohm.com/articles/bitcoins-value-is-decentralization/), [3](http://nonchalantrepreneur.com/post/70130104170/bitcoin-and-the-byzantine-generals-problem), [4](https://en.bitcoin.it/wiki/Block_chain), [5](http://www.newscientist.com/article/mg22129553.700-bitcoin-how-its-core-technology-will-change-the-world.html#.VI1NHaTF9Co)
 
-## Bitcoin has an ultra secure core protocol <a name="ultra-secure-core"></a>
+<a name="ultra-secure-core"></a>
+## Bitcoin has an ultra secure core protocol
 The Bitcoin protocol has been vetted and tested by top computer science, cryptography, and security experts around the world.
 
 Bitcoin relies on a combination of algorithms / hash functions which are heavily-used and relied upon around the world including ECDSA, SHA-2, SHA-256. Bitcoin is also a dynamic system that can be changed and adapted to address specific security vulnerabilities. 
@@ -79,7 +84,8 @@ It is important to make a distinction between the Bitcoin protocol and either Bi
 
 Further reading: [1](https://bitcoin.org/en/faq#is-bitcoin-secure), [2](http://www.michaelnielsen.org/ddi/how-the-bitcoin-protocol-actually-works/), [3](http://crypto.stackexchange.com/questions/316/how-secure-is-the-bitcoin-protocol), [4](https://en.bitcoin.it/wiki/Protocol_rules)
 
-## Bitcoin’s volatility is good for consumers <a name="volatility"></a>
+<a name="volatility"></a>
+## Bitcoin’s volatility is good for consumers
 
 Volatility is a signal to consumers that makes them fully aware of the risks associated with Bitcoin. As Bitcoin is still in BETA, someone purchasing Bitcoin is aware of the volatility which re-emphasizes the risk of investing in Bitcoin.
 
@@ -89,18 +95,22 @@ Volatility will likely decrease over time. As Bitcoin’s market capitalization 
 
 Further reading: [1](http://www.xe.com/currencytables/?from=USD&date=2014-12-05), [2](http://www.washingtonpost.com/blogs/the-switch/wp/2013/12/09/heres-why-volatility-isnt-a-big-problem-for-bitcoin/), [3](http://www.forbes.com/sites/timothylee/2013/04/12/bitcoins-volatility-is-a-disadvantage-but-not-a-fatal-one/), [4](http://www.coindesk.com/bitcoins-volatility-problem-may-soon-solved/), [5](http://www.coindesk.com/bitcoin-vs-argentine-peso-worse/)
 
-## Bitcoin is available to everyone <a name="available-to-everyone"></a>
+<a name="available-to-everyone"></a>
+## Bitcoin is available to everyone
 Unlike applying for a credit card or bank account which has many personal and financial requirements, Bitcoin is available to everyone. It also has many options. If you’d like to use a hosted wallet or exchange service, you’ll have to go through some degree of identity verification and comply with the provider’s requirements. However, this is just an option. Otherwise, you can download your own local wallet and gain complete control of your Bitcoin with a simple computer program.
 
 Also, if you want to be involved in the security and evolution of the network, anybody in the world can participate in multiple ways. If you’d like to contribute to the Bitcoin Core technology, you can [contribute via Github](https://github.com/bitcoin/bitcoin). However, a majority of the network would have to agree with your changes. To be a part of the decision-making community, you can participate in the [mining process](http://bitcoinminer.net/category/basic-overview-of-bitcoin-mining/).
 
-## Bitcoin is still in BETA - act appropriately <a name="beta"></a>
+<a name="beta"></a>
+## Bitcoin is still in BETA - act appropriately
 While the protocol is ultra-secure and heavily tested, Bitcoin is still in its infancy. This applies to both the core protocol, surrounding companies/services, and Bitcoin as a currency / transaction medium. People should clearly understand this risk and only participate with what they can afford to lose. Telling people that they should put a lot of money or resources into Bitcoin as a great way to make money is the wrong message to send.
 
-## Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run <a name="fixed-monetary-policy"></a>
+<a name="fixed-monetary-policy"></a>
+## Bitcoin’s fixed monetary policy allows for certainty and predictability in the long run
 Bitcoin volatility is present but largely market-driven. Volatility in fiat currencies is not only caused by market forces, but also monetary policy decisions that have little transparency or predictability. A fixed monetary supply (21 million Bitcoin) may provide greater certainty and predictability that allows users to make more educated decisions. 
 
-## Bitcoin is self-regulating <a name="self-regulating"></a>
+<a name="self-regulating"></a>
+## Bitcoin is self-regulating
 Bitcoin is self-regulating and makes sure certain people don’t abuse the protocol. Everyone is incentivized to make sure Bitcoin is successful, from users to miners. And, when bad-actors try to take advantage of the protocol, everyone responds to take appropriate actions.
 
 This is one of the reasons why Bitcoin is unique compared to other payments networks. Other payments networks require heavy regulation over a large, central authority.  Because Bitcoin is self-regulating and requires majority consensus on rules/protocol, it does not require nearly as heavy regulation.
@@ -111,15 +121,18 @@ Finally, there are multiple groups and associations that establish standards of 
 
 Further reading: [1](https://www.youtube.com/watch?v=xUNGFZDO8mM), [2](http://www.coindesk.com/bitcoin-industry-leaders-launch-data-a-self-regulatory-body/), [3](https://en.bitcoin.it/wiki/Mining), [4](http://www.righto.com/2014/02/bitcoin-mining-hard-way-algorithms.html), [5](http://www.coindesk.com/ghash-commits-40-hashrate-cap-bitcoin-mining-summit/)
 
-## Bitcoin is already heavily regulated by the US government and the media <a name="already-heavily-regulated"></a>
+<a name="already-heavily-regulated"></a>
+## Bitcoin is already heavily regulated by the US government and the media
 Bitcoin companies in the US have already faced massive regulatory pressure. FinCEN has issued [guidance](http://fincen.gov/statutes_regs/guidance/html/FIN-2013-G001.html) on virtual currency companies [twice](http://www.fincen.gov/news_room/rp/rulings/pdf/FIN-2014-R011.pdf). The Senate has held [hearings](http://www.hsgac.senate.gov/hearings/beyond-silk-road-potential-risks-threats-and-promises-of-virtual-currencies) on Bitcoin. The IRS has issued [tax guidance](http://www.irs.gov/pub/irs-drop/n-14-21.pdf) on Bitcoin. The CFPB has issued an [advisory notice](http://files.consumerfinance.gov/f/201408_cfpb_consumer-advisory_virtual-currencies.pdf) to consumers on how to deal with Bitcoin. New York state has proposed a [BitLicense](http://www.dfs.ny.gov/about/press2014/pr1407171-vc.pdf) for virtual currency companies. Bitcoin companies operating in the US have substantial existing regulations and compliance requirements. This is exacerbated by the fact that Bitcoin companies are under heavy scrutiny and in the spotlight. Lots of regulators, reporters, banks, and traditional financial service companies are waiting for Bitcoin companies to make major mistakes.
 
-## Bitcoin has multiple uses <a name="multiple-uses"></a>
+<a name="multiple-uses"></a>
+## Bitcoin has multiple uses
 Bitcoin is not just a virtual currency. It is also a store of value, transaction medium, value transfer protocol, and distributed consensus system. Make people aware that all of the above exist and should be treated as relatively independent concepts. 
 
 The beauty of Bitcoin is the intersection of an arguably superior currency, store of value, transaction medium, value transfer protocol, and distributed consensus system all in one manifestation. However, Bitcoin does not have to succeed in all of these pillars for it to be successful. If someone is convinced that Bitcoin will never replace gold as a store of value, remind them to consider the other pillars of Bitcoin when analyzing Bitcoin as a whole.
 
-## Bitcoin operates over a truly open payment network <a name="open"></a>
+<a name="open"></a>
+## Bitcoin operates over a truly open payment network
 Visa, Mastercard, ACH, wire transfers, and check images operate over a open-loop network which is a system of intermediaries (ex. financial institutions or banks) and end-points (ex. consumers or merchants). All of these payments methods did incredible things for digitizing payments and creating large-scale interoperability. 
 
 However, these older payment methods can be made significantly more efficient, frictionless, and open. In addition, these networks are owned by fee-taking central parties with ultimate decision-making abilities.


### PR DESCRIPTION
I quite liked this list of "main points that the Bitcoin community should focus on conveying" but as it is already quite long I missed having a Table of Contents to review the structure at a glance and jump around between sections.
